### PR TITLE
Fix PlatformType in settings for iPhone

### DIFF
--- a/projects/appium-gradle-demo/src/main/java/settings/MobileSettings.java
+++ b/projects/appium-gradle-demo/src/main/java/settings/MobileSettings.java
@@ -33,7 +33,7 @@ public class MobileSettings {
          **/
 
 
-        this.platform = PlatformType.Android;
+        this.platform = PlatformType.iOS;
         this.app = "https://github.com/dtopuzov/mobile-testing/raw/master/testapps/ios-calculator.zip";
         this.deviceName = "iPhone 5s";
         this.platformVersion = "11.3";


### PR DESCRIPTION
The Platform type should be iOS since the settings bellow are for iPhone.